### PR TITLE
feat: implement kakao login logic

### DIFF
--- a/packages/service-backend/src/modules/auth/AuthGuard.ts
+++ b/packages/service-backend/src/modules/auth/AuthGuard.ts
@@ -21,6 +21,7 @@ export class AuthGuard implements CanActivate {
       const user = await this.authService.decode(token);
 
       Reflect.defineProperty(request, 'user', { value: user });
+      return true;
     }
 
     throw new UnauthorizedException();

--- a/packages/service-frontend/app/LoginHeader.tsx
+++ b/packages/service-frontend/app/LoginHeader.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useQuery } from '@tanstack/react-query'
 import { motion, useScroll, useTransform } from 'framer-motion'
-import { redirect, useRouter } from 'next/navigation'
-import { api, authTokenRepository } from '@ppoba/api'
+import { useRouter } from 'next/navigation'
+import { authTokenRepository } from '@ppoba/api'
 import { Icon } from '@ppoba/ui'
+
+import useIsLoggedIn from '@/hooks/useIsLoggedIn'
 
 interface Props {
   onClickCreateDeck: () => void
@@ -13,20 +14,17 @@ interface Props {
 function LoginHeader({ onClickCreateDeck }: Props): JSX.Element {
   const router = useRouter();
   const { scrollY } = useScroll()
-  const { data: meData } = useQuery(
-    ['getMe'],
-    () => api.auth.getMe(),
-  )
+  const isLoggedIn = useIsLoggedIn();
 
   const y = useTransform(scrollY, [0, 100], [-2, 0])
   const opacity = useTransform(scrollY, [0, 100], [0, 1])
 
   const handleClick = () => {
-    if (meData) {
+    if (isLoggedIn) {
       authTokenRepository.clear()
-      redirect('/')
+      router.push('/', { forceOptimisticNavigation: true })
     } else {
-      router.push(`/login`)
+      router.push('/login')
     }
   };
 
@@ -55,7 +53,7 @@ function LoginHeader({ onClickCreateDeck }: Props): JSX.Element {
             role="button"
             onClick={handleClick}
           >
-            {meData ? "로그아웃" : "로그인"}
+            {isLoggedIn ? "로그아웃" : "로그인"}
           </strong>
         </div>
       </header>

--- a/packages/service-frontend/app/components/marketplace/deck/MyDeckList.tsx
+++ b/packages/service-frontend/app/components/marketplace/deck/MyDeckList.tsx
@@ -11,16 +11,11 @@ import { GameCardList, GameCardListTitle } from '../game'
 export default function MyDeckList(): JSX.Element {
   const router = useRouter()
 
-  const { data: meData } = useQuery(
-    ['getMe'],
-    () => api.auth.getMe(),
-  )
   const { data: userData, isError: isUserDataError } = useQuery(
-    ['getDeckListByUserId'],
-    () => api.deck.getDeckListByUserId({ userId: meData?.id ?? '' }),
+    ['getDeckListOfMine'],
+    () => api.deck.getDeckListOfMine(),
     {
       suspense: true,
-      enabled: !!meData?.id,
     },
   )
 

--- a/packages/service-frontend/app/components/overlay/CreateDeckOverlay.tsx
+++ b/packages/service-frontend/app/components/overlay/CreateDeckOverlay.tsx
@@ -2,6 +2,8 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { useRouter } from 'next/navigation'
 import { Icon } from '@ppoba/ui'
 
+import useIsLoggedIn from '@/hooks/useIsLoggedIn'
+
 type Props = BaseOverlayProps
 
 export default function CreateDeckOverlay({
@@ -9,6 +11,16 @@ export default function CreateDeckOverlay({
   onClickClose = () => {},
 }: Props): JSX.Element {
   const router = useRouter()
+  const isLoggedIn = useIsLoggedIn()
+
+  const handleClickCreateNewDeck = () => {
+    router.push(isLoggedIn ? '/create-title' : '/login')
+  }
+
+  const handleClickCreateByTemplate = () => {
+    router.push(isLoggedIn ? '/create-template' : '/login')
+  }
+ 
   return (
     <AnimatePresence>
       {isOpen && (
@@ -21,7 +33,7 @@ export default function CreateDeckOverlay({
         >
           <div className="flex flex-col justify-center items-center h-full gap-[10px]">
             <button
-              onClick={() => router.push('/create-title')}
+              onClick={handleClickCreateNewDeck}
               className="flex justify-center items-center w-[240px] px-[24px] py-[16px] subtitle-2 text-white text-center rounded-[32px] bg-black gap-[10px]"
             >
               <div className="p-[6px] bg-orange-01 rounded-full">
@@ -30,7 +42,7 @@ export default function CreateDeckOverlay({
               <div className="flex-1">처음부터 만들기</div>
             </button>
             <button
-              onClick={() => router.push('/create-template')}
+              onClick={handleClickCreateByTemplate}
               className="flex justify-center items-center w-[240px] px-[24px] py-[16px] subtitle-2 text-white text-center rounded-[32px] bg-black gap-[10px]"
             >
               <div className="p-[6px] bg-blue-01 rounded-full">

--- a/packages/service-frontend/app/login/page.tsx
+++ b/packages/service-frontend/app/login/page.tsx
@@ -1,14 +1,22 @@
 'use client'
 
 import Lottie from 'lottie-react'
+import { useRouter } from 'next/navigation'
 import { KakaoButton } from '@ppoba/ui'
 
+import useIsLoggedIn from '@/hooks/useIsLoggedIn'
 import loginLottie from '@/public/lottie/loginLottie.json'
 
 import { useLogin } from './hooks'
 
 export default function Login(): JSX.Element {
   const { handleLoginClick } = useLogin()
+  const isLoggedIn = useIsLoggedIn()
+  const router = useRouter()
+
+  if (isLoggedIn) {
+    router.back()
+  }
 
   return (
     <div className="min-h-screen px-[16px] py-[80px] flex flex-col justify-between">

--- a/packages/service-frontend/app/page.tsx
+++ b/packages/service-frontend/app/page.tsx
@@ -9,6 +9,7 @@ import { api } from '@ppoba/api'
 import { Icon } from '@ppoba/ui'
 
 import GameCardList from '@/app/components/marketplace/game/GameCardList'
+import useIsLoggedIn from '@/hooks/useIsLoggedIn'
 
 import Footer from './components/common/Footer'
 import AllDeckInitialItem from './components/marketplace/deck/AllDeckInitialItem'
@@ -21,6 +22,7 @@ import LoginHeader from './LoginHeader'
 
 export default function Home(): JSX.Element {
   const [isOpen, setIsOpen] = useState(false)
+  const isLoggedIn = useIsLoggedIn();
 
   const { data, isError } = useQuery(['getAllDeck'], api.deck.getAllDeck, {
     suspense: true,
@@ -53,9 +55,6 @@ export default function Home(): JSX.Element {
   if (isError) {
     redirect('/404')
   }
-
-  // TODO: 로그인 여부 임시 세팅
-  const isLoggedIn = true
 
   return (
     <main className="relative">

--- a/packages/service-frontend/hooks/useIsLoggedIn.ts
+++ b/packages/service-frontend/hooks/useIsLoggedIn.ts
@@ -1,0 +1,23 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { authTokenRepository } from '@ppoba/api'
+
+function useIsLoggedIn(): boolean {
+  const [isLogin, setIsLogin] = useState(false)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const token = authTokenRepository.getToken()
+
+      if (token) {
+        setIsLogin(true)
+      }
+    }
+  }, [])
+
+  return isLogin
+}
+
+export default useIsLoggedIn


### PR DESCRIPTION
## Issue Number

close: #127 

## Description

> 구현 내용 및 작업한 내용

- [x] 백엔드 `AuthGuard`쪽 bug fix (`header.user`를 못받아오길래 보니까 return true가 없었음)
- [x] `useIsLoggedIn` 커스텀 훅 추가 및 필요한 페이지에 적용
- [x] 내가 생성한 덱 목록 불러올 때 사용하는 API를 `getDeckListByUserId`에서 `getDeckListOfMine`으로 변경
- [x] 로그인한 유저들만 덱을 생성할 수 있도록 조건 추가 (미들웨어에 넣는 방법을 고려해봤으나 localStorage가 client side에서만 조회가 되어서 장렬히 실패)
- [x] 로그인한 유저의 경우 `/login` 페이지 접근 시 이전 페이지로 이동

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 배포 후 잘 동작하는지 확인 필요

## Checklist

> PR 등록 전 확인한 것

- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g., `feat: 로그인 페이지 추가`)
- [x] description에 PR에 대해 구체적으로 설명했는가
